### PR TITLE
Invalidate-refresh-token

### DIFF
--- a/src/kixi/heimdall/handler.clj
+++ b/src/kixi/heimdall/handler.clj
@@ -121,7 +121,7 @@
                                             (:auth-conf req)
                                             refresh-token)]
     (if ok?
-      {:status 201 :body res}
+      {:status 200 :body res}
       {:status 401 :body res})))
 
 (defn wrap-config [handler]

--- a/src/kixi/heimdall/handler.clj
+++ b/src/kixi/heimdall/handler.clj
@@ -4,18 +4,12 @@
             [ring.middleware.json :refer [wrap-json-response wrap-json-params]]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [kixi.heimdall.application :as app]
+            [kixi.heimdall.service :as service]
             [taoensso.timbre :as log]
-            [kixi.heimdall.components.database :as db]
-            [buddy.sign.jwt :as jwt]
-            [buddy.sign.util :as sign]
-            [buddy.core.keys :as ks]
-            [clj-time.core :as t]
-            [clj-time.coerce :as c]
             [clojure.java.io :as io]
-            [kixi.heimdall.user :as user]
             [clojure.edn :as edn]
             [environ.core :refer [env]]
-            [kixi.heimdall.refresh-token :as refresh-token]))
+            ))
 
 (defn get-config
   [f]
@@ -30,96 +24,29 @@
              (get-config (io/resource env-file))
              (throw e))))))
 
-(defn- pkey [auth-conf]
-  (ks/private-key
-   (io/resource (:privkey auth-conf))
-   (:passphrase auth-conf)))
-
-(defn- make-auth-token [user auth-conf]
-  (let [exp (-> (t/plus (t/now) (t/minutes 30)) (c/to-long))]
-    (jwt/sign user
-              (pkey auth-conf)
-              {:alg :rs256 :exp exp})))
-
-(defn unsign-token [auth-conf token]
-  (and token
-       (try (jwt/unsign token (ks/public-key (io/resource (:pubkey auth-conf)))
-                        {:alg :rs256 :now (c/to-long (t/now))})
-            (catch clojure.lang.ExceptionInfo e
-              (do (log/debug "Unsign refresh token failed")
-                  nil)))))
-
-(defn make-refresh-token [issued-at-time auth-conf user]
-  (let [exp (-> (t/plus (t/now) (t/days 30)) (c/to-long))]
-    (jwt/sign {:user-id (:id user)}
-              (pkey auth-conf)
-              {:alg :rs256 :iat issued-at-time :exp exp})))
-
-(defn make-token-pair! [session auth-conf user]
-  (let [issued-at-time (c/to-long (t/now))
-        refresh-token (make-refresh-token issued-at-time auth-conf user)]
-    (refresh-token/add! session {:refresh-token refresh-token
-                                 :issued issued-at-time
-                                 :user-id (:id user)})
-    {:token-pair {:auth-token (make-auth-token user auth-conf)
-                  :refresh-token refresh-token}}))
-
-(defn create-auth-token [session auth-conf credentials]
-  (let [[ok? res] (user/auth session credentials)]
-    (if ok?
-      [true (make-token-pair! session auth-conf (:user res))]
-      [false res])))
-
 (defn auth-token [req]
-  (let [[ok? res] (create-auth-token (:cassandra-session (:components req))
-                                     (:auth-conf req)
-                                     (:params req))]
+  (let [[ok? res] (service/create-auth-token (:cassandra-session (:components req))
+                                             (:auth-conf req)
+                                             (:params req))]
     (if ok?
       {:status 201 :body res}
       {:status 401 :body res})))
 
 
-(defn refresh-auth-token [session auth-conf refresh-token]
-  (if-let [unsigned (unsign-token auth-conf refresh-token)]
-    (let [user-uuid (java.util.UUID/fromString (:user-id unsigned))
-          refresh-token-data (refresh-token/find-by-user-and-issued session
-                                                                    user-uuid
-                                                                    (:iat unsigned))
-          user (user/find-by-id session user-uuid)]
-      (if (:valid refresh-token-data)
-        (do
-          (refresh-token/invalidate! session (:id refresh-token-data))
-          [true (make-token-pair! session auth-conf user)])
-        [false {:message "Refresh token revoked/deleted or new refresh token already created"}]))
-    [false {:message "Invalid or expired refresh token provided"}]))
-
-
-
-(defn refresh-auth-token-route [req]
+(defn refresh-auth-token [req]
   (let [refresh-token (-> req :params :refresh-token)
-        [ok? res] (refresh-auth-token (:cassandra-session (:components req))
-                                      (:auth-conf req)
-                                      refresh-token)]
+        [ok? res] (service/refresh-auth-token (:cassandra-session (:components req))
+                                              (:auth-conf req)
+                                              refresh-token)]
     (if ok?
       {:status 201 :body res}
       {:status 401 :body res})))
 
-(defn invalidate-refresh-token [session auth-conf refresh-token]
-  (if-let [unsigned (unsign-token auth-conf refresh-token)]
-    (let [user-uuid (java.util.UUID/fromString (:user-id unsigned))
-          refresh-token-data (refresh-token/find-by-user-and-issued session
-                                                                    user-uuid
-                                                                    (:iat unsigned))]
-      (do
-        (refresh-token/invalidate! session (:id refresh-token-data))
-        [true {:message "Invalidated successfully"}]))
-    [false {:message "Invalid or expired refresh token provided"}]))
-
-(defn invalidate-refresh-token-route [req]
+(defn invalidate-refresh-token [req]
   (let [refresh-token (-> req :params :refresh-token)
-        [ok? res] (invalidate-refresh-token (:cassandra-session (:components req))
-                                            (:auth-conf req)
-                                            refresh-token)]
+        [ok? res] (service/invalidate-refresh-token (:cassandra-session (:components req))
+                                                    (:auth-conf req)
+                                                    refresh-token)]
     (if ok?
       {:status 200 :body res}
       {:status 401 :body res})))
@@ -131,8 +58,8 @@
 (defroutes app-routes
   (GET "/" [] "Hello World")
   (POST "/create-auth-token" [] auth-token)
-  (POST "/refresh-auth-token" [] refresh-auth-token-route)
-  (POST "/invalidate-refresh-token" [] invalidate-refresh-token-route)
+  (POST "/refresh-auth-token" [] refresh-auth-token)
+  (POST "/invalidate-refresh-token" [] invalidate-refresh-token)
   (route/not-found "Not Found"))
 
 (defn wrap-catch-exceptions [handler]

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -1,0 +1,84 @@
+(ns kixi.heimdall.service
+  (:require [taoensso.timbre :as log]
+            [buddy.sign.jwt :as jwt]
+            [buddy.sign.util :as sign]
+            [buddy.core.keys :as ks]
+            [clj-time.core :as t]
+            [clj-time.coerce :as c]
+            [clojure.java.io :as io]
+            [kixi.heimdall.components.database :as db]
+            [kixi.heimdall.user :as user]
+            [kixi.heimdall.refresh-token :as refresh-token]))
+
+(defn fail
+  [message]
+  [false {:message message}])
+
+(defn success
+  [result]
+  [true result])
+
+(defn- pkey [auth-conf]
+  (ks/private-key
+   (io/resource (:privkey auth-conf))
+   (:passphrase auth-conf)))
+
+(defn- make-auth-token [user auth-conf]
+  (let [exp (-> (t/plus (t/now) (t/minutes 30)) (c/to-long))]
+    (jwt/sign user
+              (pkey auth-conf)
+              {:alg :rs256 :exp exp})))
+
+(defn unsign-token [auth-conf token]
+  (and token
+       (try (jwt/unsign token (ks/public-key (io/resource (:pubkey auth-conf)))
+                        {:alg :rs256 :now (c/to-long (t/now))})
+            (catch clojure.lang.ExceptionInfo e
+              (do (log/debug "Unsign refresh token failed")
+                  nil)))))
+
+(defn make-refresh-token [issued-at-time auth-conf user]
+  (let [exp (-> (t/plus (t/now) (t/days 30)) (c/to-long))]
+    (jwt/sign {:user-id (:id user)}
+              (pkey auth-conf)
+              {:alg :rs256 :iat issued-at-time :exp exp})))
+
+(defn make-token-pair! [session auth-conf user]
+  (let [issued-at-time (c/to-long (t/now))
+        refresh-token (make-refresh-token issued-at-time auth-conf user)]
+    (refresh-token/add! session {:refresh-token refresh-token
+                                 :issued issued-at-time
+                                 :user-id (:id user)})
+    {:token-pair {:auth-token (make-auth-token user auth-conf)
+                  :refresh-token refresh-token}}))
+
+(defn create-auth-token [session auth-conf credentials]
+  (let [[ok? res] (user/auth session credentials)]
+    (if ok?
+      (success (make-token-pair! session auth-conf (:user res)))
+      (fail "Invalid username or password"))))
+
+(defn refresh-auth-token [session auth-conf refresh-token]
+  (if-let [unsigned (unsign-token auth-conf refresh-token)]
+    (let [user-uuid (java.util.UUID/fromString (:user-id unsigned))
+          refresh-token-data (refresh-token/find-by-user-and-issued session
+                                                                    user-uuid
+                                                                    (:iat unsigned))
+          user (user/find-by-id session user-uuid)]
+      (if (:valid refresh-token-data)
+        (do
+          (refresh-token/invalidate! session (:id refresh-token-data))
+          (success  (make-token-pair! session auth-conf user)))
+        (fail "Refresh token revoked/deleted or new refresh token already created")))
+    (fail "Invalid or expired refresh token provided")))
+
+(defn invalidate-refresh-token [session auth-conf refresh-token]
+  (if-let [unsigned (unsign-token auth-conf refresh-token)]
+    (let [user-uuid (java.util.UUID/fromString (:user-id unsigned))
+          refresh-token-data (refresh-token/find-by-user-and-issued session
+                                                                    user-uuid
+                                                                    (:iat unsigned))]
+      (do
+        (refresh-token/invalidate! session (:id refresh-token-data))
+        (success {:message "Invalidated successfully"})))
+    (fail "Invalid or expired refresh token provided")))

--- a/src/migrators/cassandra/201608101143_init.clj
+++ b/src/migrators/cassandra/201608101143_init.clj
@@ -32,7 +32,7 @@
       "refresh_tokens"
       (hayt/column-definitions {:id             :uuid
                                 :user_id        :uuid
-                                :issued         :int
+                                :issued         :bigint
                                 :refresh_token  :text
                                 :valid          :boolean
                                 :primary-key [:id]})))
@@ -42,7 +42,7 @@
       "refresh_tokens_by_user_id_and_issued"
       (hayt/column-definitions {:id             :uuid
                                 :user_id        :uuid
-                                :issued         :int
+                                :issued         :bigint
                                 :refresh_token  :text
                                 :valid          :boolean
                                 :primary-key [:user_id :issued]})))))

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -49,7 +49,7 @@
 
 (defn  valid-refresh-token
   []
-  (make-refresh-token (sign/to-timestamp (t/minus (t/now) (t/hours 1)))
+  (make-refresh-token (sign/to-timestamp (t/now))
                       auth-config {:username "foo" :id #uuid "b14bf8f1-d98b-4ca2-97e9-7c95ebffbcb1"}))
 
 (defn refresh-token-record

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -105,7 +105,7 @@
                     rt/invalidate! (fn [session id] '())]
         (let [response (app (json-request (mock/request :post "/invalidate-refresh-token"
                                                         (json/write-str {:refresh-token refresh-token}))))]
-          (is (= (:status response) 201))
+          (is (= (:status response) 200))
           (is (= (:message (json/read-str (:body response) :key-fn keyword)) "Invalidated successfully"))))))
 
   (testing "invalidate refresh token - token not valid signed"

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [ring.mock.request :as mock]
             [kixi.heimdall.handler :refer :all]
+            [kixi.heimdall.service :as service]
             [kixi.heimdall.user :as user]
             [kixi.heimdall.refresh-token :as rt]
             [buddy.hashers :as hs]
@@ -49,8 +50,8 @@
 
 (defn  valid-refresh-token
   []
-  (make-refresh-token (sign/to-timestamp (t/now))
-                      auth-config {:username "foo" :id #uuid "b14bf8f1-d98b-4ca2-97e9-7c95ebffbcb1"}))
+  (service/make-refresh-token (sign/to-timestamp (t/now))
+                              auth-config {:username "foo" :id #uuid "b14bf8f1-d98b-4ca2-97e9-7c95ebffbcb1"}))
 
 (defn refresh-token-record
   [refresh-token]


### PR DESCRIPTION
* New route to invalidate the refresh token.
* Test the invalidate token route
* Test the refresh token route
* Change the timestamps associated with the refresh tokens (`:exp` and `:iat`) to contain millisecond to differentiate two timestamps create very close in time.