### PR TITLE
Fix/comms broker ids

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [environ "1.1.0"]
                  [aero "1.0.0"]
-                 [kixi/kixi.comms "0.1.17-SNAPSHOT"]
+                 [kixi/kixi.comms "0.1.17"]
                  [org.clojure/tools.analyzer "0.6.9"]
                  ;; not really dependency, dep collision https://groups.google.com/forum/#!topic/clojure/D_s9Drua6D4
                  ]

--- a/project.clj
+++ b/project.clj
@@ -33,7 +33,7 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [environ "1.1.0"]
                  [aero "1.0.0"]
-                 [kixi/kixi.comms "0.1.11"]
+                 [kixi/kixi.comms "0.1.17-SNAPSHOT"]
                  [org.clojure/tools.analyzer "0.6.9"]
                  ;; not really dependency, dep collision https://groups.google.com/forum/#!topic/clojure/D_s9Drua6D4
                  ]

--- a/resources/conf.edn
+++ b/resources/conf.edn
@@ -12,10 +12,12 @@
                                 :production 3000}}
  :communications {:kafka #profile {:development {:host "localhost"
                                                  :port 2181
-                                                 :group-id "heimdall"}
+                                                 :group-id "heimdall"
+                                                 :zk-path "/"}
                                    :production {:host "master.mesos"
                                                 :port 2181
-                                                :group-id "heimdall"}}}
+                                                :group-id "heimdall"
+                                                :zk-path "/dcos-service-kafka/"}}}
  :auth-conf {:privkey #profile {:development "auth_privkey.pem"
                                 :test "test_privkey.pem"
                                 :production "/root/prod_privkey.pem"}


### PR DESCRIPTION
use new version of comms with deployment fix to use a zookeeper path.