### PR TITLE
for purpose of sharing: having 'user groups'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -49,4 +49,5 @@
          :dependencies [[javax.servlet/servlet-api "2.5"]
                         [ring/ring-mock "0.3.0"]
                         [org.clojure/data.json "0.2.6"]]}}
-  :aliases {"seed" ["run" "-m" "joplin.alias/seed" "joplin.edn"]})
+  :aliases {"seed" ["run" "-m" "joplin.alias/seed" "joplin.edn"],
+           ,"migrate" ["run" "-m" "joplin.alias/migrate" "joplin.edn"]})

--- a/resources/conf.edn
+++ b/resources/conf.edn
@@ -44,8 +44,8 @@
                                              :port 2181
                                              :group-id "heimdall_test"
                                              :zk-path "/dcos-service-kafka/"
-                                             :topics {:command "command-test"
-                                                      :event "event-test"}}
+                                             :topics {:command "command-heimdall-testing"
+                                                      :event "event-heimdall-testing"}}
                                    :production {:host "master.mesos"
                                                 :port 2181
                                                 :group-id "heimdall"

--- a/src/kixi/heimdall/components/database.clj
+++ b/src/kixi/heimdall/components/database.clj
@@ -81,7 +81,7 @@
           reformatted (map util/underscore->hyphen result)]
       reformatted))
   (select* [this table where]
-    (let [result (exec conn (hayt/select table (hayt/where where)))
+    (let [result (exec conn (hayt/select table (hayt/where (util/hyphen->underscore where))))
           reformatted (map util/underscore->hyphen result)]
       (if (coll? result)
         (map (partial into {}) reformatted)
@@ -97,9 +97,9 @@
   (update! [this table what where]
     (exec conn (hayt/update table (hayt/set-columns
                                    (into {} (util/underscore->hyphen what)))
-                            (hayt/where where))))
+                            (hayt/where (util/hyphen->underscore where)))))
   (delete! [this table where]
-    (exec conn (hayt/delete table (hayt/where (into {} (util/hyphen->underscore where)))))))
+    (exec conn (hayt/delete table (hayt/where (into {} (util/hyphen->underscore (util/hyphen->underscore where))))))))
 
 (defrecord CassandraSession [opts profile]
   Database
@@ -118,7 +118,7 @@
           reformatted (map util/underscore->hyphen result)]
       reformatted))
   (select* [this table where]
-    (let [result (exec this (hayt/select table (hayt/where where)))
+    (let [result (exec this (hayt/select table (hayt/where (util/hyphen->underscore where))))
           reformatted (map util/underscore->hyphen result)]
       (if (coll? result)
         (map (partial into {}) reformatted)
@@ -134,7 +134,7 @@
   (update! [this table what where]
     (exec this (hayt/update table (hayt/set-columns
                                    (into {} (util/underscore->hyphen what)))
-                            (hayt/where where))))
+                            (hayt/where (util/hyphen->underscore where)))))
   (delete! [this table where]
     (exec this (hayt/delete table (hayt/where (into {} (util/hyphen->underscore where))))))
 

--- a/src/kixi/heimdall/group.clj
+++ b/src/kixi/heimdall/group.clj
@@ -4,7 +4,7 @@
             [qbits.alia.uuid :as uuid]
             [taoensso.timbre :as log]))
 
-(defn create!
+(defn add!
   [session {:keys [name user-id] :as group}]
   (let [group-id (uuid/random)
         group-data {:id group-id

--- a/src/kixi/heimdall/group.clj
+++ b/src/kixi/heimdall/group.clj
@@ -5,22 +5,31 @@
             [taoensso.timbre :as log]))
 
 (defn add!
-  [session {:keys [name user-id] :as group}]
+  [session {:keys [name user-id group-type] :as group}]
   (let [group-id (uuid/random)
         group-data {:id group-id
                     :name name
+                    :group-type (or group-type "group")
                     :created-by user-id
                     :created (util/db-now)}]
     (db/insert! session :groups group-data)
+    (db/insert! session :groups_by_user_and_type group-data)
     {:group-id group-id}))
-
-(defn update!
-  [session group-id {:keys [name]}]
-  (db/update! session :groups {:name name} {:id (java.util.UUID/fromString group-id)}))
 
 (defn find-by-id
   [session id]
-  (first (db/select* session :groups {:id id}))  )
+  (first (db/select* session :groups {:id id})))
+
+(defn find-user-group
+  [session user-id]
+  (first (db/select* session :groups_by_user_and_type {:created-by user-id
+                                                       :group-type "user"})))
+
+(defn update!
+  [session group-id {:keys [name]}]
+  (db/update! session :groups {:name name} {:id (java.util.UUID/fromString group-id)})
+  (let [group (find-by-id session (java.util.UUID/fromString group-id))]
+    (db/update! session :groups_by_user_and_type {:name name} {:created-by (:created-by group) :group-type (:group-type group)})))
 
 (defn all
   [session]

--- a/src/kixi/heimdall/member.clj
+++ b/src/kixi/heimdall/member.clj
@@ -6,7 +6,7 @@
   [session id]
   (map :group-id (db/select session :members_by_user [:group-id] {:user-id id})))
 
-(defn add-user-to-group
+(defn add!
   [session user-id group-id]
   {:pre [user-id group-id]}
   (db/insert! session :members_by_group

--- a/src/kixi/heimdall/schema.clj
+++ b/src/kixi/heimdall/schema.clj
@@ -15,9 +15,10 @@
   (re-find #"(?=.*\d.*)(?=.*[a-z].*)(?=.*[A-Z].*).{8,}" s))
 
 (spec/def ::group-name string?)
+(spec/def ::group-type #{"user" "group"})
 (spec/def ::group-params
   (spec/keys :req-un [::group-name]
-             :opts [] ))
+             :opts [::group-type] ))
 
 
 (spec/def ::uuid #(instance? java.util.UUID %))

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -121,9 +121,9 @@
 (defn- create-group
   [session {:keys [group user]}]
   (let [user-id  (java.util.UUID/fromString (:id user))
-        group-id (:group-id (group/create! session {:name (:group-name group)
-                                                    :user-id user-id}))]
-    (member/add-user-to-group session user-id group-id)
+        group-id (:group-id (group/add! session {:name (:group-name group)
+                                                 :user-id user-id}))]
+    (member/add! session user-id group-id)
     {:group-id group-id}))
 
 (defn new-user
@@ -144,7 +144,7 @@
   (let [_ (log/info "GROUP-ID" group-id (type group-id))
         user-id  (java.util.UUID/fromString user-id)
         group-id (java.util.UUID/fromString group-id)]
-    (member/add-user-to-group session user-id group-id)))
+    (member/add! session user-id group-id)))
 
 (defn add-member-event
   [session communications user-id group-id]

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -144,15 +144,13 @@
 
 (defn- add-member
   [session {:keys [user-id group-id]}]
-  (let [_ (log/info "GROUP-ID" group-id (type group-id))
-        user-id  (java.util.UUID/fromString user-id)
+  (let [user-id  (java.util.UUID/fromString user-id)
         group-id (java.util.UUID/fromString group-id)]
     (member/add! session user-id group-id)))
 
 (defn add-member-event
   [session communications user-id group-id]
-  (let [_ (log/info "GROUP-ID" group-id)
-        user-ok? (and (spec/valid? :kixi.heimdall.schema/id user-id)
+  (let [user-ok? (and (spec/valid? :kixi.heimdall.schema/id user-id)
                       (user/find-by-id session (java.util.UUID/fromString user-id)))
         group-ok? (and (spec/valid? :kixi.heimdall.schema/id group-id)
                        (group/find-by-id session (java.util.UUID/fromString group-id)))]

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -134,7 +134,10 @@
       (if (user/find-by-username session {:username (:username credentials)})
         (fail "There is already a user with this username.")
         (do
-          (user/add! session credentials)
+          (let [added-user (user/add! session credentials)]
+            (group/add! session {:name (:username credentials)
+                                 :user-id (:id added-user)
+                                 :group-type "user"}))
           (comms/send-event! communications :kixi.heimdall/user-created "1.0.0" (select-keys params [:username]))
           (success {:message "User successfully created!"})))
       (fail (str "Please match the required format: " res)))))

--- a/src/kixi/heimdall/user.clj
+++ b/src/kixi/heimdall/user.clj
@@ -23,10 +23,11 @@
 
 (defn add!
   [session user]
-  (let [user-data (-> user
+  (let [user-id (uuid/random)
+        user-data (-> user
                       (update-in [:password] #(hs/encrypt %))
                       (assoc :created (util/db-now)
-                             :id (uuid/random)))]
+                             :id user-id))]
     (db/insert! session :users_by_username
                 user-data)
     (db/insert! session :users

--- a/src/migrators/cassandra/20160902111300_init.clj
+++ b/src/migrators/cassandra/20160902111300_init.clj
@@ -1,10 +1,12 @@
-(ns migrators.cassandra.201609021113-init
+(ns migrators.cassandra.20160902111300-init
   (:use [joplin.cassandra.database])
   (:require [qbits.alia :as alia]
-            [qbits.hayt :as hayt]))
+            [qbits.hayt :as hayt]
+            [taoensso.timbre :as log]))
 
 (defn up
   [db]
+  (log/info "Joplin up" db)
   (let [conn (get-connection (:hosts db) (:keyspace db))]
     (alia/execute
      conn
@@ -52,21 +54,9 @@
       "groups"
       (hayt/column-definitions {:id           :uuid
                                 :name         :text
-                                :group_type   :text
                                 :created      :timestamp
                                 :created_by   :uuid
                                 :primary-key  [:id]})))
-
-    (alia/execute
-     conn
-     (hayt/create-table
-      "groups_by_user_and_type"
-      (hayt/column-definitions {:id           :uuid
-                                :name         :text
-                                :group_type   :text
-                                :created      :timestamp
-                                :created_by   :uuid
-                                :primary-key  [:created_by :group_type]})))
 
     ;; to get all groups a user belongs to, and their roles in it
     (alia/execute
@@ -94,4 +84,6 @@
     (alia/execute conn (hayt/drop-table "users_by_username"))
     (alia/execute conn (hayt/drop-table "refresh_tokens"))
     (alia/execute conn (hayt/drop-table "refresh_tokens_by_user_id_and_issued"))
-    (alia/execute conn (hayt/drop-table "groups"))))
+    (alia/execute conn (hayt/drop-table "groups"))
+    (alia/execute conn (hayt/drop-table "members_by_group"))
+    (alia/execute conn (hayt/drop-table "members_by_user"))))

--- a/src/migrators/cassandra/201609021113_init.clj
+++ b/src/migrators/cassandra/201609021113_init.clj
@@ -46,16 +46,27 @@
                                 :refresh_token  :text
                                 :valid          :boolean
                                 :primary-key    [:user_id :issued]})))
-
     (alia/execute
      conn
      (hayt/create-table
       "groups"
       (hayt/column-definitions {:id           :uuid
                                 :name         :text
+                                :group_type   :text
                                 :created      :timestamp
                                 :created_by   :uuid
                                 :primary-key  [:id]})))
+
+    (alia/execute
+     conn
+     (hayt/create-table
+      "groups_by_user_and_type"
+      (hayt/column-definitions {:id           :uuid
+                                :name         :text
+                                :group_type   :text
+                                :created      :timestamp
+                                :created_by   :uuid
+                                :primary-key  [:created_by :group_type]})))
 
     ;; to get all groups a user belongs to, and their roles in it
     (alia/execute

--- a/src/migrators/cassandra/20170109125300_adding_self_groups.clj
+++ b/src/migrators/cassandra/20170109125300_adding_self_groups.clj
@@ -1,0 +1,33 @@
+(ns migrators.cassandra.20170109125300-adding-self-groups
+  (:use [joplin.cassandra.database])
+  (:require [qbits.alia :as alia]
+            [qbits.hayt :as hayt]))
+
+(defn up
+  [db]
+  (let [conn (get-connection (:hosts db) (:keyspace db))]
+    (alia/execute
+     conn
+     (hayt/alter-table
+      :groups
+      (hayt/add-column :group_type :text)))
+
+    (alia/execute
+     conn
+     (hayt/create-table
+      "groups_by_user_and_type"
+      (hayt/column-definitions {:id           :uuid
+                                :name         :text
+                                :group_type   :text
+                                :created      :timestamp
+                                :created_by   :uuid
+                                :primary-key  [:created_by :group_type]})))))
+
+(defn down [db]
+  (let [conn (get-connection (:hosts db) (:keyspace db))]
+    (alia/execute
+     conn
+     (hayt/alter-table
+      "groups"
+      (hayt/drop-column :group_type)))
+    (alia/execute conn (hayt/drop-table "groups_by_user_and_type"))))

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -243,16 +243,18 @@
 
 (deftest new-user-test
   (testing "new user can be added if password passes the validation"
-    (with-redefs [user/add! (fn [_ _] '())
-                  user/find-by-username (fn [_ _] nil)]
+    (with-redefs [user/add! (fn [_ _] {:user-id (java.util.UUID/randomUUID)})
+                  user/find-by-username (fn [_ _] nil)
+                  group/add! (fn [_ _] {:group-id (java.util.UUID/randomUUID)})]
       (let [response (comms-app app (heimdall-request
                                      (mock/request :post "/user"
                                                    (json/write-str {:username "user@boo.com"
                                                                     :password "secret1Pass"}))))]
         (is (= (:status response) 201)))))
   (testing "new user can not be added if password fails the validation"
-    (with-redefs [user/add! (fn [_ _] '())
-                  user/find-by-username (fn [_ _] nil)]
+    (with-redefs [user/add! (fn [_ _] {:user-id (java.util.UUID/randomUUID)})
+                  user/find-by-username (fn [_ _] nil)
+                  group/add! (fn [_ _] {:group-id (java.util.UUID/randomUUID)})]
       (let [response (comms-app app (heimdall-request
                                      (mock/request :post "/user"
                                                    (json/write-str {:username "user@boo.com"
@@ -261,8 +263,9 @@
         (is (= (:body response)
                "user-creation-failed")))))
   (testing "new user triggers a send-event!"
-    (with-redefs [user/add! (fn [_ _] '())
-                  user/find-by-username (fn [_ _] nil)]
+    (with-redefs [user/add! (fn [_ _] {:user-id (java.util.UUID/randomUUID)})
+                  user/find-by-username (fn [_ _] nil)
+                  group/add! (fn [_ _] {:group-id (java.util.UUID/randomUUID)})]
       (let [events (atom {})
             response (comms-app app (heimdall-request
                                      (mock/request :post "/user"

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -95,7 +95,9 @@
                     rt/add! (fn [session m] true)
                     member/retrieve-groups-ids (fn [session user-id]
                                                  '({:group-id "group-id-1"}
-                                                   {:group-id "group-id-2"}))]
+                                                   {:group-id "group-id-2"}))
+                    group/find-user-group (fn [session user-id]
+                                            {:id (java.util.UUID/randomUUID)})]
         (let [events (atom {})
               response (comms-app app (heimdall-request
                                        (mock/request :post "/create-auth-token"
@@ -103,11 +105,12 @@
           (is (= (:status response) 201))
           (let [body-resp (json/read-str (:body response) :key-fn keyword)]
             (is (:token-pair body-resp)))
-          (is (= @events {:comms {:sent '({:event :kixi.heimdall/user-logged-in :version "1.0.0" :payload {:username "user@boo.com"}})}}))          )))
+          (is (= @events {:comms {:sent '({:event :kixi.heimdall/user-logged-in :version "1.0.0" :payload {:username "user@boo.com"}})}})))))
     (testing "authentication fails wrong user"
       (with-redefs [user/find-by-username (fn [session m] nil)
                     member/retrieve-groups-ids (fn [session user-id]
-                                                 '())]
+                                                 '())
+                    group/find-user-group (fn [session _] nil)]
         (let [response (comms-app app (heimdall-request
                                        (mock/request :post "/create-auth-token"
                                                      (json/write-str {:username "user@boo.com" :password "foo12CCbb"}))))]

--- a/test/kixi/heimdall/handler_test.clj
+++ b/test/kixi/heimdall/handler_test.clj
@@ -213,10 +213,10 @@
 
 (deftest test-create-group
   (testing "the /create-route route works"
-    (with-redefs [group/create! (fn [session group-name]
-                                  {:group-id #uuid "bfa00b8a-f57e-43ff-829b-d7469e797000"})
-                  member/add-user-to-group (fn [session user-id grp-id role]
-                                             '())]
+    (with-redefs [group/add! (fn [session group-name]
+                               {:group-id #uuid "bfa00b8a-f57e-43ff-829b-d7469e797000"})
+                  member/add! (fn [session user-id grp-id role]
+                                '())]
       (let [events (atom {})
             response (comms-app app (heimdall-request
                                      (mock/header (mock/request :post "/group"


### PR DESCRIPTION
* groups that are created at same time as the user, with the same name, designed to represent just that user
* a group type that can be 'group' and 'user' depending
* groups column indexed by user id and group type, to be able to find both the user corresponding to a user group and the group corresponding to a user
* a little bit of cleanup and renaming