### PR TITLE
Correcting profile based selection of log appender

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Wait until the system has settled before proceeding.
 To start the application, run:
 
 ```
-lein run -m kixi.heimdall.bootstrap -p <development/production>
+lein run -m kixi.heimdall.bootstrap -p <development/prod>
 ```
 
 ## Development docker image

--- a/src/kixi/heimdall/system.clj
+++ b/src/kixi/heimdall/system.clj
@@ -20,7 +20,7 @@
         _ (reset! app/profile profile)]
     (log/set-config! {:level (keyword (env :log-level (get-in config [:logging :level])))
                       :timestamp-opts kixi-log/default-timestamp-opts
-                      :appenders (if (#{:production :staging} profile)
+                      :appenders (if (#{:prod :staging} profile)
                                    {:direct-json (kixi-log/timbre-appender-logstash)}
                                    {:println (log/println-appender)})})
     (when (get-in config [:logging :kixi-comms-verbose-logging])


### PR DESCRIPTION
The profile is actually 'prod', this fix should stop heimdall errors
appearing in kibana line by line.