### PR TITLE
User data created on invite

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,14 @@ Beforehand:
 
 **To invite a new user:**
 ```
-(k/invite-user! "foo@bar.com")
+(k/invite-user! "foo@bar.com" "FooBar")
 ```
-This will produce an 'invite code' which the user can then use to signup via the `/signup` route.
+This will create the user, their self group, and produce an 'invite code' which the user can then use to signup via the `/signup` route.
+
+```
+(k/invite-user! "foo@bar.com" "FooBar" ["Group"])
+```
+This will create the user, their self group, ensure they are a member (creating as required) of "Group", and produce an 'invite code' which the user can then use to signup via the `/signup` route.
 
 **To change a user's password:**
 ```

--- a/src/kixi/heimdall/components/persistence.clj
+++ b/src/kixi/heimdall/components/persistence.clj
@@ -39,7 +39,7 @@
            (c/attach-event-handler! communications
                                     :kixi.heimdall/persistence-invite-create
                                     :kixi.heimdall/invite-created
-                                    "1.0.0"
+                                    "2.0.0"
                                     (comp (constantly nil) (partial #'service/save-invite db) :kixi.comms.event/payload))
            (c/attach-event-handler! communications
                                     :kixi.heimdall/persistence-password-reset-request-create

--- a/src/kixi/heimdall/group.clj
+++ b/src/kixi/heimdall/group.clj
@@ -20,7 +20,8 @@
       (db/put-item db
                    groups-table
                    group-data
-                   {:return :none}))))
+                   {:return :none
+                    :cond-expr "attribute_not_exists(id)"}))))
 
 (defn find-by-id
   [db id]

--- a/src/kixi/heimdall/handler.clj
+++ b/src/kixi/heimdall/handler.clj
@@ -50,9 +50,9 @@
       (return-error {:msg res :fn "auth-token"} :unauthenticated 401))))
 
 (defn new-user [req]
-  (let [[ok? res] (service/new-user-with-invite (dynamodb req)
-                                                (communications req)
-                                                (:params req))]
+  (let [[ok? res] (service/signup-user! (dynamodb req)
+                                        (communications req)
+                                        (:params req))]
     (if ok?
       {:status 201 :body res}
       (return-error {:msg res :fn "new-user"} :user-creation-failed 400))))

--- a/src/kixi/heimdall/invites.clj
+++ b/src/kixi/heimdall/invites.clj
@@ -13,21 +13,25 @@
   [ic un]
   (str "/#/invite?ic=" ic "&un=" un))
 
-(defn create-invite-failed-event
-  [reason username]
-  {:kixi.comms.event/key :kixi.heimdall/invite-failed
-   :kixi.comms.event/version "1.0.0"
-   :kixi.comms.event/payload {:reason reason
-                              :username username}})
+(defn failed-event
+  ([username reason]
+   (failed-event username reason nil))
+  ([username reason explain]
+   {:kixi.comms.event/key :kixi.heimdall/invite-failed
+    :kixi.comms.event/version "2.0.0"
+    :kixi.comms.event/payload (merge {:reason reason
+                                      :username username}
+                                     (when explain
+                                       {:explain explain}))}))
 
 (defn create-invite-event
-  [username]
+  [user]
   (let [ic (util/create-code)]
     {:kixi.comms.event/key :kixi.heimdall/invite-created
-     :kixi.comms.event/version "1.0.0"
-     :kixi.comms.event/payload {:username (clojure.string/lower-case username)
+     :kixi.comms.event/version "2.0.0"
+     :kixi.comms.event/payload {:user user
                                 :invite-code ic
-                                :url (invite-code->url ic username)}}))
+                                :url (invite-code->url ic (:username user))}}))
 
 (defn save!
   [db invite-code username']

--- a/src/kixi/heimdall/member.clj
+++ b/src/kixi/heimdall/member.clj
@@ -18,7 +18,10 @@
                members-table
                {:user-id user-id
                 :group-id group-id}
-               {:return :all-old}))
+               {:return :all-old
+                :expr-attr-names {"#ui" "user-id"
+                                  "#gi" "group-id"}
+                :cond-expr "attribute_not_exists(#ui) AND attribute_not_exists(#gi)"}))
 
 (defn remove-member
   [db {:keys [user-id group-id]}]

--- a/src/kixi/heimdall/schema.clj
+++ b/src/kixi/heimdall/schema.clj
@@ -23,6 +23,7 @@
 (spec/def ::username email?)
 (spec/def ::created util/date-time?)
 (spec/def ::exp integer?)
+(spec/def ::pre-signup boolean?)
 
 (spec/def ::user-id uuid?)
 (spec/def ::group-id uuid?)
@@ -36,13 +37,15 @@
 (spec/def ::user-groups (spec/keys :req-un [::groups] :opts []))
 (spec/def ::user
   (spec/keys :req-un [::id]
-             :opts [::username ::name ::created ::user-groups]))
+             :opts [::username ::name ::created ::user-groups ::pre-signup]))
 
 
 (spec/def ::password password?)
 (spec/def ::login
   (spec/keys :req-un [::username ::password]))
 
+(spec/def ::user-invite
+  (spec/keys :req-un [::username ::name]))
 
 (spec/def ::name string?)
 (spec/def ::self-group uuid?)

--- a/test/kixi/heimdall/integration/invites_test.clj
+++ b/test/kixi/heimdall/integration/invites_test.clj
@@ -40,24 +40,24 @@
                                          invites-table
                                          {:username (clojure.string/lower-case username)}
                                          {:consistent? true})]
-    (service/invite-user! @db-session @comms username)
+    (service/invite-user! @db-session @comms {:username username :name "Invite Test"})
     (wait-for get-invite-code-fn
               #(throw (Exception. "Invite code never arrived.")))
     (when-let [invite-code-item (get-invite-code-fn)]
       (let [[username-fail? username-res]
-            (service/new-user-with-invite @db-session @comms {:username "wrong-email@foo.com"
-                                                              :name "Invite Test"
-                                                              :password "Foobar123"
-                                                              :invite-code (:invite-code invite-code-item)})
+            (service/signup-user! @db-session @comms {:username "wrong-email@foo.com"
+                                                      :name "Invite Test"
+                                                      :password "Foobar123"
+                                                      :invite-code (:invite-code invite-code-item)})
             [ic-fail? ic-res]
-            (service/new-user-with-invite @db-session @comms {:username username
-                                                              :name "Invite Test"
-                                                              :password "Foobar123"
-                                                              :invite-code "123456789"})
-            [ok? res] (service/new-user-with-invite @db-session @comms {:username username
-                                                                        :name "Invite Test"
-                                                                        :password "Foobar123"
-                                                                        :invite-code (:invite-code invite-code-item)})]
+            (service/signup-user! @db-session @comms {:username username
+                                                      :name "Invite Test"
+                                                      :password "Foobar123"
+                                                      :invite-code "123456789"})
+            [ok? res] (service/signup-user! @db-session @comms {:username username
+                                                                :name "Invite Test"
+                                                                :password "Foobar123"
+                                                                :invite-code (:invite-code invite-code-item)})]
         (is (not username-fail?))
         (is (not ic-fail?))
         (is ok? (str res))))))

--- a/test/kixi/heimdall/integration/user_test.clj
+++ b/test/kixi/heimdall/integration/user_test.clj
@@ -11,8 +11,12 @@
   (let [username-wacky-case (random-email)
         user {:id (str (java.util.UUID/randomUUID))
               :username username-wacky-case
-              :password "changeme"}]
+              :password "changeme"
+              :signed-up "timestamp"
+              :pre-signup true}]
     (add! @db-session user)
+    (signed-up! @db-session (assoc user
+                                   :pre-signup false))
     (is (first (auth @db-session (update user :username clojure.string/lower-case))))))
 
 (deftest change-password-test-success

--- a/test/kixi/heimdall/invites_test.clj
+++ b/test/kixi/heimdall/invites_test.clj
@@ -8,15 +8,15 @@
     (is event)
     (is #{:kixi.comms.event/key :kixi.comms.event/version :kixi.comms.event/payload}
         (= (set (keys event))))
-    (let [{:keys [url username invite-code]} (:kixi.comms.event/payload event)]
-      (is (= username name))
+    (let [{:keys [url user invite-code]} (:kixi.comms.event/payload event)]
+      (is (= user name))
       (is invite-code)
       (is url)
       (is (pos? (.indexOf url invite-code))))))
 
 (deftest invite-event-fail
   (let [name "foo@bar"
-        event (create-invite-failed-event "You failed" name)]
+        event (failed-event "You failed" name)]
     (is event)
     (is #{:kixi.comms.event/key :kixi.comms.event/version :kixi.comms.event/payload}
         (= (set (keys event))))


### PR DESCRIPTION
When a user is invited the user data and self group data is
created. Users in this state are marked by the flag :pre-signup. These
users can be added to groups, kaylee namespace allows user and group
creation/joining, but they can not sign in. The signin protection is
based on the state flag and the nil password column.

State transistions are managed by events, but in keeping with Heimdall
current layout there are no Commands for these actions.