### PR TITLE
User reads via Username routed to main table

### DIFF
--- a/src/kixi/heimdall/member.clj
+++ b/src/kixi/heimdall/member.clj
@@ -8,8 +8,9 @@
   (map :group-id (db/query db
                            members-table
                            {:user-id [:eq id]}
-                           {;;:index members-table
-                            :return [:group-id :s]})))
+                           { ;;:index members-table
+                            :return [:group-id :s]
+                            :consistent? true})))
 
 (defn add!
   [db {:keys [user-id group-id]}]

--- a/src/kixi/heimdall/user.clj
+++ b/src/kixi/heimdall/user.clj
@@ -60,22 +60,24 @@
                      :cond-expr "attribute_exists(id) AND #ps = :true"})
     user-data))
 
-(defn find-by-username
-  [db {:keys [username]}]
-  (first
-   (db/query db
-             user-table
-             {:username [:eq (clojure.string/lower-case username)]}
-             {:index users-by-username
-              :limit 1
-              :return :all-attributes})))
-
 (defn find-by-id
   [db id]
   (db/get-item db
                user-table
                {:id id}
                {:consistent? true}))
+
+(defn find-by-username
+  [db {:keys [username]}]
+  (some->> (db/query db
+                     user-table
+                     {:username [:eq (clojure.string/lower-case username)]}
+                     {:index users-by-username
+                      :limit 1
+                      :return [:id]})
+           first
+           :id
+           (find-by-id db)))
 
 (defn auth
   [db {:keys [username password]}]


### PR DESCRIPTION
Global Secondary Indexes can not be consistently read in Dynamodb (grrr), so having to do this.

Wasn't a problem before, as user rows were never updated, but now, with the pre-signup flag, we need to ensure the system is always getting the lastest information.