### PR TITLE
Adding event constraint tests

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [kixi/joplin.dynamodb "0.3.10-SNAPSHOT"]
                  [cider/cider-nrepl "0.13.0"]
                  ;; these are dependencies around running the server in the repl
+                 [org.clojure/core.async "0.3.443"]
                  [org.clojure/tools.namespace    "0.2.11"]
                  [org.clojure/tools.nrepl        "0.2.12"]
                  [org.clojure/tools.cli "0.3.5"]

--- a/src/kixi/heimdall/components/database.clj
+++ b/src/kixi/heimdall/components/database.clj
@@ -7,7 +7,7 @@
             [kixi.heimdall.config :as config]
             [kixi.heimdall.application :as app]
             [taoensso.faraday :as far]
-            [kixi.heimdall.cloudwatch :refer [table-dynamo-alarms]]            ))
+            [kixi.heimdall.cloudwatch :refer [table-dynamo-alarms]]))
 
 (def app "kixi.heimdall")
 

--- a/src/kixi/heimdall/member.clj
+++ b/src/kixi/heimdall/member.clj
@@ -3,6 +3,8 @@
 
 (def members-table "members-groups")
 
+(def group-members-dex "groups-members")
+
 (defn retrieve-groups-ids
   [db id]
   (map :group-id (db/query db
@@ -11,6 +13,14 @@
                            { ;;:index members-table
                             :return [:group-id :s]
                             :consistent? true})))
+
+(defn retrieve-member-ids
+  [db group-id]
+  (map :user-id (db/query db
+                           members-table
+                           {:group-id [:eq group-id]}
+                           {:index group-members-dex
+                            :return [:user-id :s]})))
 
 (defn add!
   [db {:keys [user-id group-id]}]

--- a/test/kixi/heimdall/integration/event_constraints_test.clj
+++ b/test/kixi/heimdall/integration/event_constraints_test.clj
@@ -1,0 +1,199 @@
+(ns kixi.heimdall.integration.event-constraints-test
+  (:require [clojure.core.async :as async]
+            [clojure.test :refer :all]
+            [kixi.comms :as kcomms]
+            [kixi.heimdall.components.database :as db]
+            [kixi.heimdall.group :as group]
+            [kixi.heimdall.integration.base :refer :all]
+            [kixi.heimdall.invites :as invites]
+            [kixi.heimdall.kaylee :as k]
+            [kixi.heimdall.member :as member]
+            [kixi.heimdall.service :as service]
+            [kixi.heimdall.user :as user]))
+
+(use-fixtures :once cycle-system extract-db-session extract-comms)
+
+(defn uid
+  []
+  (str (java.util.UUID/randomUUID)))
+
+(defn user-groups
+  [user]
+  (member/retrieve-groups-ids @db-session (:id user)))
+
+(defn group-users
+  [group]
+  (member/retrieve-member-ids @db-session (:id group)))
+
+(defn wait-for-user-invite
+  [username]
+  (wait-for #(db/get-item @db-session
+                          invites/invites-table
+                          {:username username}
+                          {:consistent? true})
+            #(throw (Exception. "Invite code never arrived."))))
+
+(defn create-users-in-a-shared-group
+  [username1 username2 groupname]
+  (let [name1 (str username1 "-" (uid))
+        username1 (str name1 "@mastodonc.com")
+        name2 (str username2 "-" (uid))
+        username2 (str name2 "@mastodonc.com")
+        groupname (str "groupname" (uid))]
+    (with-redefs [k/db    (fn [] @db-session)
+                  k/comms (fn [] @comms)]
+      (k/invite-user! username1 name1 [groupname])
+      (k/invite-user! username2 name2 [groupname])
+      (let [user1-ic (wait-for-user-invite username1)
+            user2-ic (wait-for-user-invite username2)]
+        (is user1-ic)
+        (is user2-ic)
+        (when (and user1-ic user2-ic)
+          (service/signup-user! @db-session @comms {:username username1
+                                                    :name name1
+                                                    :password "Foobar123"
+                                                    :invite-code (:invite-code user1-ic)})
+          (service/signup-user! @db-session @comms {:username username2
+                                                    :name name2
+                                                    :password "Foobar123"
+                                                    :invite-code (:invite-code user2-ic)}))
+        [username1 username2 groupname]))))
+
+(defn get-entities
+  [username1 username2 groupname]
+  [(user/find-by-username @db-session {:username username1})
+   (user/find-by-username @db-session {:username username2})
+   (group/find-by-name @db-session groupname)])
+
+(defn check-group-assignment
+  ([user1 user2 group]
+   (check-group-assignment
+    user1 user2 group 2))
+  ([user1 user2 group expected-count]
+   (is (= expected-count
+          (count (user-groups user1))))
+   (is (= expected-count
+          (count (user-groups user2))))
+   (is (= expected-count
+          (count (group-users group))))
+   [user1 user2 group]))
+
+(defn attach-event-listener
+  [group-id]
+  (let [event-chan (async/chan 100)]
+    [(kcomms/attach-event-with-key-handler! @comms
+                                             group-id
+                                             :kixi.comms.event/id
+                                             (fn [msg]
+                                               (async/>!! event-chan msg)
+                                               nil))
+     event-chan]))
+
+(defn detach-listener
+  [handler]
+  (kcomms/detach-handler! @comms handler))
+
+(defn wait-for-dynamo-consistency
+  []
+  (Thread/sleep 3000))
+
+(defn collect-events
+  [event-chan events-atom]
+  (loop [[msg _] (async/alts!! [event-chan
+                                (async/timeout 1000)])]
+    (when msg
+      (swap! events-atom conj msg)
+      (recur (async/alts!! [event-chan
+                            (async/timeout 1000)])))))
+
+(defn resend-events
+  [events]
+  (doseq [event (sort-by :kixi.comms.event/created-at 
+                         (fn [^String x ^String y] 
+                           (.compareTo x y))
+                         events)]
+    (kcomms/send-event! @comms
+                        (:kixi.comms.event/key event)
+                        (:kixi.comms.event/version event)
+                        (:kixi.comms.event/payload event)
+                        {})))
+
+(deftest events-are-idempotent
+  (let [[event-handler event-chan] (attach-event-listener "idempotent-test")
+        [username1 username2 groupname] (create-users-in-a-shared-group "idempotent-test-1"
+                                                                        "idempotent-test-2"
+                                                                        "idempotent-group")
+        [user1 user2 group] (get-entities username1 username2 groupname)]
+    (check-group-assignment user1 user2 group)
+    (let [msg-set (atom #{})]
+      (collect-events event-chan msg-set)
+      (is (= 6 
+             (count @msg-set)))
+      (detach-listener event-handler)
+      (resend-events @msg-set)
+      (wait-for-dynamo-consistency)
+      (check-group-assignment user1 user2 group))))
+
+(defn delete-entries
+  [user1 user2 group]
+  (db/delete-item @db-session
+                  member/members-table                  
+                  {:user-id (:id user1)
+                   :group-id (:id group)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  member/members-table                  
+                  {:user-id (:id user2)
+                   :group-id (:id group)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  member/members-table                  
+                  {:user-id (:id user1)
+                   :group-id (:group-id user1)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  member/members-table                  
+                  {:user-id (:id user2)
+                   :group-id (:group-id user2)}
+                  {:return :none})
+
+  (db/delete-item @db-session
+                  group/groups-table
+                  {:id (:id group)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  group/groups-table
+                  {:id (:group-id user1)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  group/groups-table
+                  {:id (:group-id user2)}
+                  {:return :none})
+
+  (db/delete-item @db-session
+                  user/user-table
+                  {:id (:id user1)}
+                  {:return :none})
+  (db/delete-item @db-session
+                  user/user-table
+                  {:id (:id user2)}
+                  {:return :none}))
+
+(deftest event-replay-restores-state
+  (let [[event-handler event-chan] (attach-event-listener "replay-test")
+        [username1 username2 groupname] (create-users-in-a-shared-group "replay-test-1"
+                                                                        "replay-test-2"
+                                                                        "replay-group")
+        [user1 user2 group] (get-entities username1 username2 groupname)]
+    (check-group-assignment user1 user2 group)
+    (let [msg-set (atom #{})]
+      (collect-events event-chan msg-set)
+      (is (= 6 
+             (count @msg-set)))
+      (detach-listener event-handler)
+      (delete-entries user1 user2 group)
+      (wait-for-dynamo-consistency)
+      (check-group-assignment user1 user2 group 0)
+      (resend-events @msg-set))
+    (wait-for-dynamo-consistency)
+    (check-group-assignment user1 user2 group)))

--- a/test/kixi/heimdall/integration/kaylee_test.clj
+++ b/test/kixi/heimdall/integration/kaylee_test.clj
@@ -59,8 +59,7 @@
         username (str name "@mastodonc.com")
         unwanted-name (str "unwanted-group-member-" (java.util.UUID/randomUUID))
         unwanted-username (str unwanted-name "@mastodonc.com")
-        groupname (str "remove-usergroup-name-" (java.util.UUID/randomUUID))
-        new-pass "Barfoo321"]
+        groupname (str "remove-usergroup-name-" (java.util.UUID/randomUUID))]
     (with-redefs [k/db    (fn [] @db-session)
                   k/comms (fn [] @comms)]
       (k/invite-user! username name)


### PR DESCRIPTION
There are two tests added.

The first, creates two users and adds them
to a shared group. The events for these actions tracked, and
resent. The test then checks that both the users appear in the groups
the correct number of times.

The second, creates the users and group again, then deletes all the
rows associated with them and resends the events. Checking that they
end up back where they were.

This gives us some confidents for both event replay and event idempotence.