### PR TITLE
Add group-type to all group creation events

### DIFF
--- a/src/kixi/heimdall/handler.clj
+++ b/src/kixi/heimdall/handler.clj
@@ -85,7 +85,8 @@
                                          {:group-name group-name
                                           :group-id group-id
                                           :user-id (:user-id req)
-                                          :created created}))]
+                                          :created created
+                                          :group-type "group"}))]
     (if ok?
       {:status 201 :body "Group successfully created"}
       (return-error {:msg "Please provide valid parameters (name for the group)" :fn "create-group"} :group-creation-failed 400))))

--- a/src/kixi/heimdall/kaylee.clj
+++ b/src/kixi/heimdall/kaylee.clj
@@ -53,7 +53,8 @@
                                         {:group-name group-name
                                          :group-id group-id
                                          :created (util/db-now)
-                                         :user-id (:id user)})
+                                         :user-id (:id user)
+                                         :group-type "group"})
           (wait-for #(group/find-by-name (db) group-name))
           :failed-create-group)))
     :failed-no-user))

--- a/src/kixi/heimdall/schema.clj
+++ b/src/kixi/heimdall/schema.clj
@@ -30,8 +30,7 @@
 (spec/def ::group-name string?)
 (spec/def ::group-type #{"user" "group"})
 (spec/def ::group-params
-  (spec/keys :req-un [::group-name ::group-id ::user-id ::created]
-             :opts [::group-type]))
+  (spec/keys :req-un [::group-name ::group-id ::user-id ::created ::group-type]))
 
 (spec/def ::groups (spec/coll-of ::uuid))
 (spec/def ::user-groups (spec/keys :req-un [::groups] :opts []))

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -216,7 +216,7 @@
                  (update :username clojure.string/lower-case)
                  create-user-data)]
     (cond
-      (not (spec/valid? ::schema/user-invite user)) (invites/failed-event username :invalid-data (spec/explain-data ::schema/user-invite user))     
+      (not (spec/valid? ::schema/user-invite user)) (invites/failed-event username :invalid-data (spec/explain-data ::schema/user-invite user))
       (and stored-user
            (not (:pre-signup stored-user))) (invites/failed-event username :user-signedup)
       :else (invites/create-invite-event user))))

--- a/test/kixi/heimdall/integration/base.clj
+++ b/test/kixi/heimdall/integration/base.clj
@@ -132,5 +132,6 @@
         _ (#'service/create-group session {:group-id group-id
                                            :created (util/db-now)
                                            :group-name group-name
-                                           :user-id (str owner-id)})]
+                                           :user-id (str owner-id)
+                                           :group-type "group"})]
     [owner-id group-id]))

--- a/test/kixi/heimdall/integration/group_admin_test.clj
+++ b/test/kixi/heimdall/integration/group_admin_test.clj
@@ -31,7 +31,8 @@
           group-created (#'service/create-group @db-session {:group-id (uid)
                                                              :group-name (str "fantastic four " (java.util.UUID/randomUUID))
                                                              :user-id user-id
-                                                             :created (util/db-now)})]
+                                                             :created (util/db-now)
+                                                             :group-type "group"})]
       (is (== (count (member/retrieve-groups-ids @db-session user-id)) 1))))
 
   (testing "creation after sending an event"
@@ -41,7 +42,8 @@
           creation-params {:group-id (uid)
                            :group-name (str "the avengers " (java.util.UUID/randomUUID))
                            :user-id user-id
-                           :created (util/db-now)}
+                           :created (util/db-now)
+                           :group-type "group"}
           event-ok? (service/create-group-event @db-session @comms creation-params)]
       (is (true? event-ok?))
       (wait-for #(first (member/retrieve-groups-ids @db-session user-id))


### PR DESCRIPTION
This field was optional, but is now being upgraded to required.

At this time we are about to reprocess all our events, so historical
instances are being corrected as part of that work.