### PR TITLE
Adding extra partition key finder for send email cmd

### DIFF
--- a/src/kixi/heimdall/email.clj
+++ b/src/kixi/heimdall/email.clj
@@ -13,7 +13,8 @@
                           "1.0.0"
                           user
                           mail
-                          {:kixi.comms.command/partition-key (:kixi.user/id user)})))
+                          {:kixi.comms.command/partition-key (or (:kixi.user/id user)
+                                                                 (:id user))})))
 
 (defmulti send-email!
   (fn [email-type comms opts] email-type))


### PR DESCRIPTION
The user map for the password resets looks like it's a different, an
incorrect, shape. This is a hot fix as prod is effected right now. We
need to work out why the tests aren't exposing these issues.