### PR TITLE
Adding span-req settings to table scans

### DIFF
--- a/src/kixi/heimdall/components/database.clj
+++ b/src/kixi/heimdall/components/database.clj
@@ -91,7 +91,10 @@
                      opts))
   (scan [this table]
     (far/scan (db this)
-              (decorated-table table (prefix this))))
+              (decorated-table table (prefix this))
+              {:limit 50
+               :span-reqs {:max 100
+                           :throttle-ms 100}}))
 
   component/Lifecycle
   (start [component]


### PR DESCRIPTION
Adding a limit of 50 per individual request in the scan, increasing
the maximum number of requests in the scan to 100 and introducing a
wait of 100 millis between each request.

We are having trouble with scan requests on the production heimdall
tables, we could just increase the limits, but that can only go so far
as we scan tables when user's login. This change will slow down the
login experience a little, but treat the tables a little better.

This will take some tuning.