### PR TITLE
User IDs are maintained when user re-invited.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :description "Authentication and authorization service"
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
+  :dependencies [[org.clojure/clojure "1.9.0-beta1"]
+                 [org.clojure/test.check "0.9.0"]
                  [compojure "1.5.1"]
                  [ring/ring-defaults "0.2.1"]
                  [kixi/buddy "1.2.1" :exclusions [cheshire]]
@@ -14,6 +15,7 @@
                  [com.taoensso/faraday "1.9.0" :exclusions [com.amazonaws/aws-java-sdk-dynamodb]]
                  [kixi/kixi.log "0.1.5"]
                  [kixi/kixi.metrics "0.4.1"]
+                 [kixi/kixi.spec "0.1.13"]
                  [metrics-clojure ~metrics-version]
                  [metrics-clojure-jvm ~metrics-version]
                  [metrics-clojure-ring ~metrics-version]

--- a/src/kixi/heimdall/patches/patch_20170629.clj
+++ b/src/kixi/heimdall/patches/patch_20170629.clj
@@ -34,27 +34,28 @@
   [u]
   (service/send-user-created-event! (comms) u))
 
+(comment
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Users
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(def users
-  (map #(dissoc % :password) (user/all (db))))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Groups
+  ;; Users
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(def groups
-  (group/all (:db @kixi.heimdall.application/system)))
+  (def users
+    (map #(dissoc % :password) (user/all (db))))
 
-(defn send-group-created-event!
-  [group]
-  (comms/send-event! (comms) :kixi.heimdall/group-created "2.0.0" group))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ;; Groups
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+  (def groups
+    (group/all (:db @kixi.heimdall.application/system)))
+
+  (defn send-group-created-event!
+    [group]
+    (comms/send-event! (comms) :kixi.heimdall/group-created "2.0.0" group))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn apply-patch!
-  []
-  (run! send-user-created-event! users)
-  (run! send-group-created-event! groups))
+  (defn apply-patch!
+    []
+    (run! send-user-created-event! users)
+    (run! send-group-created-event! groups)))

--- a/src/kixi/heimdall/schema.clj
+++ b/src/kixi/heimdall/schema.clj
@@ -45,7 +45,7 @@
   (spec/keys :req-un [::username ::name]))
 
 (spec/def ::name string?)
-(spec/def ::self-group uuid?)
+(spec/def ::self-group ks/uuid?)
 (spec/def ::user-groups (spec/coll-of ::id))
 (spec/def ::auth-token
   (spec/keys :req-un [::id

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -238,7 +238,7 @@
                                                                        (s/explain-data ::schema/user-invite user))
       (and stored-user
            (not (:pre-signup stored-user))) (invites/failed-event username :user-signedup)
-      :else  (invites/create-invite-event user))))
+      :else (invites/create-invite-event user))))
 
 (defn user-invite-event-payload->kixi-user
   [{{:keys [id group-id]}

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -208,17 +208,37 @@
          :pre-signup true
          :group-id (str (java.util.UUID/randomUUID))))
 
-(defn user-invite-event!
+(s/fdef user-invite-event
+        :args (s/cat :stored-user (s/nilable ::schema/stored-user)
+                     :invitee (s/keys :req-un [::schema/username ::schema/name]))
+        :fn (fn [{:keys [args ret]}]
+              (let [{:keys [stored-user invitee]} args
+                    [_ event] ret
+                    tested-keys [:id :group-id :created]]
+                (cond
+                  (:pre-signup stored-user)
+                  (= (select-keys stored-user
+                                  tested-keys)
+                     (select-keys (get-in event [:kixi.comms.event/payload :user])
+                                  tested-keys))
+                  :else true)))
+
+        :ret (s/or :created ::invites/create-invite-event
+                   :failed ::invites/failed-event))
+
+(defn user-invite-event
   [stored-user {:keys [username name] :as user'}]
   (let [user (-> user'
                  (select-keys [:username :name])
                  (update :username clojure.string/lower-case)
-                 create-user-data)]
+                 create-user-data
+                 (merge (select-keys stored-user [:id :group-id :created])))]
     (cond
-      (not (s/valid? ::schema/user-invite user)) (invites/failed-event username :invalid-data (s/explain-data ::schema/user-invite user))
+      (not (s/valid? ::schema/user-invite user)) (invites/failed-event username :invalid-data
+                                                                       (s/explain-data ::schema/user-invite user))
       (and stored-user
            (not (:pre-signup stored-user))) (invites/failed-event username :user-signedup)
-      :else (invites/create-invite-event user))))
+      :else  (invites/create-invite-event user))))
 
 (defn user-invite-event-payload->kixi-user
   [{{:keys [id group-id]}
@@ -231,7 +251,7 @@
   (let [stored-user (user/find-by-username db {:username username})
         {:keys [kixi.comms.event/key
                 kixi.comms.event/version
-                kixi.comms.event/payload] :as event} (user-invite-event! stored-user user)]
+                kixi.comms.event/payload] :as event} (user-invite-event stored-user user)]
     (comms/send-event! communications
                        key
                        version

--- a/test/kixi/heimdall/unit/invites_test.clj
+++ b/test/kixi/heimdall/unit/invites_test.clj
@@ -1,0 +1,23 @@
+(ns kixi.heimdall.unit.invites-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test.check :as tc]
+            [kixi.heimdall.invites :as sut]))
+
+(def sample-size 100)
+
+(defn check
+  [sym]
+  (-> sym
+      (stest/check {:clojure.spec.test.alpha.check/opts {:num-tests sample-size}})
+      first
+      stest/abbrev-result
+      :failure))
+
+(deftest check-create-invite-event
+  (is (nil?
+       (check `sut/create-invite-event))))
+
+(deftest check-failed-event
+  (is (nil?
+       (check `sut/failed-event))))

--- a/test/kixi/heimdall/unit/service_test.clj
+++ b/test/kixi/heimdall/unit/service_test.clj
@@ -1,0 +1,19 @@
+(ns kixi.heimdall.unit.service-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec.test.alpha :as stest]
+            [clojure.test.check :as tc]
+            [kixi.heimdall.service :as sut]))
+
+(def sample-size 100)
+
+(defn check
+  [sym]
+  (-> sym
+      (stest/check {:clojure.spec.test.alpha.check/opts {:num-tests sample-size}})
+      first
+      stest/abbrev-result
+      :failure))
+
+(deftest check-user-invite-event
+  (is (nil?
+       (check `sut/user-invite-event))))

--- a/test/kixi/heimdall/unit/user_invite.clj
+++ b/test/kixi/heimdall/unit/user_invite.clj
@@ -1,0 +1,2 @@
+(ns kixi.heimdall.unit.user-invite
+  (:require [clojure.test :refer :all]))


### PR DESCRIPTION
- Fixes a bug where this wasn't happening.
- Added spec to invite and failure events.
- Created fdef for invited user.
- Added generative tests to assert the bug fixed.

Known issues:

- unit/service-test/check wrapper for spec/check to expose failures is
  a hack.

- alias of :user to :invited-user in invites.clj feels like its
  covering a deeper problem.

- introduction of kixi.spec, but not really properly used yet.

- s/fdef service/user-invite-event the fn predicate does not propogate
  error nicely at present (look to use key+pred pairs in the future)