### PR TITLE
Adding fdef and post assertion for signup-user

### DIFF
--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -17,7 +17,8 @@
             [kixi.heimdall.email :as email]
             [kixi.heimdall.schema :as schema]
             [kixi.heimdall.components.database :as database]
-            [kixi.comms :refer [Communications] :as comms]))
+            [kixi.comms :refer [Communications] :as comms]
+            [kixi.spec.conformers :as kc]))
 
 (defn fail
   [message]
@@ -185,14 +186,12 @@
                      :communications (s/keys)
                      :params (s/keys :req-un [::schema/username
                                               ::schema/password])))
+(s/def ::message kc/not-empty-string)
+(s/def ::signup-user-response (s/tuple boolean? (s/keys :req-un [::message])))
 
 (defn signup-user!
   [db communications params]
-  {:post [(vector? %)
-          (boolean? (first %))
-          (map? (second %))
-          (not-empty (:message (second %)))
-          (string? (:message (second %)))]}
+  {:post [(s/valid? ::signup-user-response %)]}
   (let [user' (-> params
                   (select-keys [:username :password])
                   (update :username clojure.string/lower-case))

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -16,6 +16,7 @@
             [kixi.heimdall.util :as util]
             [kixi.heimdall.email :as email]
             [kixi.heimdall.schema :as schema]
+            [kixi.heimdall.components.database :as database]
             [kixi.comms :refer [Communications] :as comms]))
 
 (defn fail
@@ -179,8 +180,19 @@
       (comment "This should only work on event replay, when the condition will succeed.")))
   nil)
 
+(s/fdef signup-user!
+        :args (s/cat :db (s/keys)
+                     :communications (s/keys)
+                     :params (s/keys :req-un [::schema/username
+                                              ::schema/password])))
+
 (defn signup-user!
   [db communications params]
+  {:post [(vector? %)
+          (boolean? (first %))
+          (map? (second %))
+          (not-empty (:message (second %)))
+          (string? (:message (second %)))]}
   (let [user' (-> params
                   (select-keys [:username :password])
                   (update :username clojure.string/lower-case))

--- a/test/kixi/heimdall/integration/base.clj
+++ b/test/kixi/heimdall/integration/base.clj
@@ -4,12 +4,15 @@
             [kixi.comms.components.kinesis :as kinesis]
             [taoensso.timbre :as log]
             [amazonica.aws.dynamodbv2 :as ddb]
+            [clojure.spec.alpha :as s]
             [clojure.spec.test.alpha :as stest]
+            [clojure.spec.gen.alpha :as gen]
             [kixi.heimdall.config :as config]
             [kixi.heimdall.util :as util]
             [kixi.heimdall.service :as service]
             [kixi.heimdall.invites :refer [get-invite]]
-            [kixi.heimdall.user :as u :refer [find-by-username]]))
+            [kixi.heimdall.user :as u :refer [find-by-username]]
+            [kixi.spec.conformers :as kc]))
 
 (def system (atom nil))
 (def comms-mode (first (keys (:communications (config/config (keyword (env :system-profile "test")))))))
@@ -29,10 +32,8 @@
    (apply str (take len (repeatedly #(if (zero? (rand-int 2)) (char (+ (rand 26) 65)) (char (+ (rand 26) 97))))))))
 
 (defn random-email
-  ([]
-   (random-email 10 10))
-  ([pl sl]
-   (apply str (rand-str pl) "@" (rand-str sl) "." (rand-str 3))))
+  []
+  (first (gen/sample (s/gen kc/email?) 1)))
 
 (defn table-exists?
   [endpoint table]

--- a/test/kixi/heimdall/integration/kaylee_test.clj
+++ b/test/kixi/heimdall/integration/kaylee_test.clj
@@ -78,7 +78,7 @@
                                                     :password "Foobar123"
                                                     :invite-code (:invite-code unwanted-ic)})
           (is (map? (k/create-group! groupname username)))
-         
+
           (let [unwanted-user (user/find-by-username @db-session {:username unwanted-username})
                 user (user/find-by-username @db-session {:username username})]
             (is (= 2
@@ -110,7 +110,7 @@
                                     {:consistent? true})
                       #(throw (Exception. "Invite code never arrived.")))]
       (is r)
-      (when r          
+      (when r
         (let [user (user/find-by-username @db-session {:username username})
               groups (group/find-by-user @db-session (:id user))]
           (is (= 2


### PR DESCRIPTION
It didnt look worth introducing a spec check for signup-user fn,
because its very impure as used from the web handler.

Instead we introduced a small args test via fdef, and enabled
spec/instrument for the fn. We then added a post assertion for the
return type and enable asserts at test time in the cycle system fixture.