### PR TITLE
Improving add-member-to-group failure scenarios

### DIFF
--- a/src/kixi/heimdall/kaylee.clj
+++ b/src/kixi/heimdall/kaylee.clj
@@ -73,13 +73,17 @@
   [group-name user-name]
   (let [user (user/find-by-username (db) {:username user-name})
         group (group/find-by-name (db) group-name)]
-    (if (service/add-member-event (db)
-                                  (comms)
-                                  (:id user) (:id group))
+    (if (and user
+             group
+             (service/add-member-event (db)
+                                       (comms)
+                                       (:id user) (:id group)))
       (wait-for #(let [groups (member/retrieve-groups-ids (db) (:id user))]
                    (when (contains? (set groups) (:id group))
-                     :success-user-added-to-group)))
-      :failed-add-user-to-group)))
+                     {:success-user-added-to-group {:user user
+                                                    :group group}})))
+      {:failed-add-user-to-group {:user user
+                                  :group group}})))
 
 (defn invite-user!
   ([username name]

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -327,7 +327,7 @@
                               :group-valid group-ok?
                               :group-id group-id
                               :user-id user-id}
-                             {:kixi.comms.event/partition-key group-id}) false))))
+                             {:kixi.comms.event/partition-key (or group-id user-id (uuid))}) false))))
 
 (defn remove-member
   [db {:keys [user-id group-id] :as member}]

--- a/src/kixi/heimdall/service.clj
+++ b/src/kixi/heimdall/service.clj
@@ -211,13 +211,17 @@
               (send-user-created-event! communications added-user)
               (success {:message "User successfully created"})))))
 
+(defn uuid
+  []
+  (str (java.util.UUID/randomUUID)))
+
 (defn create-user-data
   [user]
   (assoc user
-         :id (str (java.util.UUID/randomUUID))
+         :id (uuid)
          :created (str (util/db-now))
          :pre-signup true
-         :group-id (str (java.util.UUID/randomUUID))))
+         :group-id (uuid)))
 
 (s/fdef user-invite-event
         :args (s/cat :stored-user (s/nilable ::schema/stored-user)
@@ -291,7 +295,8 @@
                              "1.0.0"
                              {:user-id user-id
                               :group-id group-id}
-                             {:kixi.comms.event/partition-key group-id}) true)
+                             {:kixi.comms.event/partition-key group-id})
+          true)
       (do (comms/send-event! communications
                              :kixi.heimdall/member-added-failed
                              "1.0.0"
@@ -299,7 +304,8 @@
                               :group-valid group-ok?
                               :group-id group-id
                               :user-id user-id}
-                             {:kixi.comms.event/partition-key group-id}) false))))
+                             {:kixi.comms.event/partition-key (or group-id user-id (uuid))})
+          false))))
 
 (defn remove-member-event
   [db communications user-id group-id]


### PR DESCRIPTION
Change introduces and or for the parition-key when sending failed to
add events, tries user, group ids, then gives up and creates a random
uid.

Change to kaylee name space to not attempt to add a member to group if
either group or user isn't found, improved error and success messages
to give more information.