### PR TITLE
Increase the max/default number of items returned to 200

### DIFF
--- a/src/kixi/heimdall/handler.clj
+++ b/src/kixi/heimdall/handler.clj
@@ -101,7 +101,7 @@
   {:status 200 :body {:type "users" :items (service/members-of-group (dynamodb req) (get (:params req) "id"))}})
 
 (defn get-all-groups [req]
-  (let [max-count 100
+  (let [max-count 200
         dex (util/str->int (get-in req [:params "index"]) 0)
         cnt (min (util/str->int (get-in req [:params "count"]) max-count) max-count)
         sort-order (get-in req [:params :sort-order] "desc")]


### PR DESCRIPTION
**Increase the max/default number of items returned to 200**
This is a hacky fix for a bug where not all groups are being returned